### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,22 +17,22 @@
     }
   ],
   "dependencies": {
-    "async": "^0.9.0",
-    "coffee-script": "^1.9.0",
-    "commander": "^2.1.0",
-    "debug": "^2.2.0",
-    "fbp": "^1.1.3",
-    "msgflo": "^0.4.0",
+    "async": "0.9.2",
+    "coffee-script": "1.10.0",
+    "commander": "2.8.1",
+    "debug": "2.2.0",
+    "fbp": "1.1.3",
+    "msgflo": "0.4.2",
     "newrelic": "1.17.3",
-    "noflo": "^0.5.11"
+    "noflo": "0.5.13"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
-    "grunt": "~0.4.1",
-    "mocha": "^2.2.5",
-    "noflo-core": "^0.1.13",
-    "noflo-objects": "^0.1.12",
-    "randomstring": "^1.0.3"
+    "chai": "1.10.0",
+    "grunt": "0.4.5",
+    "mocha": "2.3.3",
+    "noflo-core": "0.1.14",
+    "noflo-objects": "0.1.12",
+    "randomstring": "1.1.0"
   },
   "bin": {
     "noflo-runtime-msgflo": "./bin/noflo-runtime-msgflo"


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>