### PR TITLE
Updated msgflo to version 0.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "commander": "2.8.1",
     "debug": "2.2.0",
     "fbp": "1.1.3",
-    "msgflo": "0.4.2",
+    "msgflo": "0.5.8",
     "newrelic": "1.22.1",
     "noflo": "0.5.13"
   },


### PR DESCRIPTION
:rocket:

msgflo just published version 0.5.8, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 44 commits (ahead by 44, behind by 0).

- [be7de15](https://github.com/msgflo/msgflo/commit/be7de15f3c787b1f0c6e894ea6723679e38c162e): Keep the definition
- [98c9b72](https://github.com/msgflo/msgflo/commit/98c9b727224edd74a2db448feca58cb0c1762726): Bump
- [776d374](https://github.com/msgflo/msgflo/commit/776d37402f361a323bf9814798c42b67632e8702): Merge pull request #22 from msgflo/register_foreign_participant
- [7ed739f](https://github.com/msgflo/msgflo/commit/7ed739f27429331a78ff3ea07dc95cbcf2c2723c): Expose the foreign participant interface
- [5e42106](https://github.com/msgflo/msgflo/commit/5e4210679f34bffc4019031477cec422e7561d53): Make port mapper available externally
- [90a70bb](https://github.com/msgflo/msgflo/commit/90a70bb921e16a0e787f33582446d8dd3c00d05a): Connect to broker before registering
- [8894855](https://github.com/msgflo/msgflo/commit/889485533a41c111b3417d56723f5128f3bd5649): No debug here
- [0c01b41](https://github.com/msgflo/msgflo/commit/0c01b41277d2096c40ec44cd5a66e7ab7ad1b54a): Tool for registering foreign participants
- [a983bb5](https://github.com/msgflo/msgflo/commit/a983bb57d131eba8b23bc2ee1f731537430c5b1d): coordinator: Fix coffeelint
- [b456399](https://github.com/msgflo/msgflo/commit/b456399b50eefb1714c6616029ab2a1ce9915594): Travis: Automatic deploy to NPM
- [6d0efcc](https://github.com/msgflo/msgflo/commit/6d0efcc3579a132ed90050ac790323c0083ce03c): Bump with new msgflo-nodejs
- [3a53c3b](https://github.com/msgflo/msgflo/commit/3a53c3b378703b728740e3fbca75fd5735162397): Bump with new msgflo-nodejs
- [6c2cc84](https://github.com/msgflo/msgflo/commit/6c2cc846159143f0445e538a1a75586ec48b8718): Bump
- [91ccfb5](https://github.com/msgflo/msgflo/commit/91ccfb5855aecb70d157567cdca0e79b80a3c8d2): setup: Fix broken logic with new isParticipant() handling
- [a266db6](https://github.com/msgflo/msgflo/commit/a266db6be389e0d7792ab514f744f8219859080f): Grunt: Allow to grep for tests using TESTS envvar


There are 44 commits in total. See the [full diff](https://github.com/msgflo/msgflo/compare/a67064d4101ce06bf8ef936a40dd65a35dde795f...be7de15f3c787b1f0c6e894ea6723679e38c162e).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>